### PR TITLE
chore/Atualização Yarn 4.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "main": "index.js",
   "repository": "https://github.com/solussaude/Delphi-Mocks.git",
   "license": "MIT",
-  "packageManager": "yarn@4.2.2",
+  "packageManager": "yarn@4.13.0",
   "private": true
 }


### PR DESCRIPTION
Atualização automática do gerenciador de pacotes:

- `packageManager` atualizado de `yarn@4.2.2` para `yarn@4.13.0`
- `yarn.lock` regenerado